### PR TITLE
Adding support for vscode in ldebug

### DIFF
--- a/_lib/lmake_runtime.py
+++ b/_lib/lmake_runtime.py
@@ -51,6 +51,26 @@ def run_pdb(dbg_dir,redirected,func,*args,**kwds) :
 		traceback.print_exception(e)
 		debugger.interaction(None,e.__traceback__)
 
+def run_vscode(dbg_dir,redirected,func,*args,**kwds) :
+	import json
+	import os
+	import psutil
+	try :
+		# Write python process information to vscode debug workspace to allow gdb to attache to it
+		workspace = dbg_dir + '/vscode/ldebug.code-workspace'
+		if os.path.exists(workspace):
+			data = json.load(open(workspace))
+			for elm in data['launch']['configurations']:
+				if "type" in elm and elm["type"] == "by-gdb" : 
+					if 'processId' in elm : elm['processId'] = os.getpid()
+					if 'program' in elm : elm['program'] = ' '.join(psutil.Process(os.getpid()).cmdline())
+			print(json.dumps(data,indent='\t'),file=open(workspace,'w'))
+		# call cmd
+		func(*args,**kwds)
+	except BaseException as e :
+		import traceback
+		traceback.print_exception(e)
+
 def run_pudb(dbg_dir,redirected,func,*args,**kwds) :
 	import os
 	import pudb.debugger

--- a/doc/lmake.texi
+++ b/doc/lmake.texi
@@ -637,7 +637,7 @@ If a target does not exist, it is deemed secondary information and is shown in g
 
 @section @code{ldebug}
 
-Usage : @code{ldebug [-g|--graphic] target}
+Usage : @code{ldebug [-g|--graphic] [-c|--vscode] target}
 
 @code{ldebug} runs a job in a debug environment.
 
@@ -646,6 +646,7 @@ For now, this command is rudimentary :
 @itemize @minus
 @item it runs the script under @code{pdb} or (@code{pudb} with the graphic option) for python rules
 @item it runs the script with @code{-x} flag set for shell rules
+@item it runs the script under vscode to allow debugging python and C++ code by attaching it to the python process.
 @end itemize
 
 Special care has been taken so that :

--- a/src/ldebug.cc
+++ b/src/ldebug.cc
@@ -17,7 +17,8 @@ int main( int argc , char* argv[] ) {
 	Trace trace("main") ;
 
 	ReqSyntax syntax{{},{
-		{ ReqFlag::Graphic , { .short_name='g' , .doc="use GUI" } }
+		{ ReqFlag::Graphic , { .short_name='g' , .doc="use GUI" } },
+		{ ReqFlag::Vscode  , { .short_name='c' , .doc="launch execution under vscode control" } }
 	}} ;
 	ReqCmdLine cmd_line{syntax,argc,argv} ;
 

--- a/src/rpc_client.hh
+++ b/src/rpc_client.hh
@@ -59,6 +59,7 @@ ENUM( ReqFlag                          // PER_CMD : add flags as necessary (you 
 ,	ForgetOldErrors                    // if proc==                  Make               , assume old errors are transcient
 ,	Freeze                             // if proc==                         Mark        , prevent job rebuild
 ,	Graphic                            // if proc== Debug                          Show , use GUI to show debug script
+,	Vscode                             // if proc== Debug                          Show , use Vscode GUI to show debug script
 ,	Job                                //                                                 interpret (unique) arg as job name
 ,	Jobs                               // if proc==                  Make               , max number of jobs
 ,	KeepTmp                            // if proc==                  Make               , keep tmp dir after job execution


### PR DESCRIPTION
ldebug can now be use with vscode with -c argument passed as parameter. The code allow to install required plugin in order to debug python and C++ code.

The code will make the script command to install required plugin for python and C++