### PR TITLE
fix path outputting in sys_config.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FORCE : ;
 sys_config.env : FORCE
 	@if [ ! -f $@ ] ; then                   \
 		echo new $@ ;                        \
-		{	echo PATH=$$PATH               ; \
+		{	echo PATH=\"$$PATH\"           ; \
 			echo CXX=$$CXX                 ; \
 			echo PYTHON2=$$PYTHON2         ; \
 			echo PYTHON=$$PYTHON           ; \


### PR DESCRIPTION
This change is needed in order to handle paths that were originally between quotes.
For example, for this path:
```
PATH=/mnt/c/Program Files (x86)/[...]
```