### PR TITLE
fix test suite failing because of audit stats

### DIFF
--- a/_lib/ut.py
+++ b/_lib/ut.py
@@ -72,7 +72,7 @@ class Ut :
 			if seen_summary :
 				self.summary += l+'\n'
 				continue
-			m = re.fullmatch(rf"({Esc}\][^{Alert}]*{Alert})?({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress audit stats & color
+			m = re.fullmatch(rf"({Esc}\][^{Alert}]*{Alert})*({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress audit stats & color
 			if not m : continue
 			k = m.group('key')
 			if k in cnt : cnt[k] += 1

--- a/_lib/ut.py
+++ b/_lib/ut.py
@@ -11,7 +11,8 @@ import subprocess as sp
 import sys
 import time
 
-Esc = '\x1b'
+Esc   = '\x1b'
+Alert = '\a'
 
 # make a simplified pdict instead of importing from lmake to avoid loading c code and depending on python version
 class pdict(dict) :
@@ -71,7 +72,7 @@ class Ut :
 			if seen_summary :
 				self.summary += l+'\n'
 				continue
-			m = re.fullmatch(rf"({Esc}\][^{Bell}]*{Bell})?({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress audit stats & color
+			m = re.fullmatch(rf"({Esc}\][^{Alert}]*{Alert})?({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress audit stats & color
 			if not m : continue
 			k = m.group('key')
 			if k in cnt : cnt[k] += 1

--- a/_lib/ut.py
+++ b/_lib/ut.py
@@ -71,7 +71,7 @@ class Ut :
 			if seen_summary :
 				self.summary += l+'\n'
 				continue
-			m = re.fullmatch(rf"({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress color
+			m = re.fullmatch(rf"({Esc}\][^{Bell}]*{Bell})?({Esc}\[[0-9;]*m)?(\d\d:\d\d:\d\d(\.\d+)? )?{'.'*self.host_len+' ' if self.host_len else ''}(?P<key>\w+) .*",l) # suppress audit stats & color
 			if not m : continue
 			k = m.group('key')
 			if k in cnt : cnt[k] += 1


### PR DESCRIPTION
Using codec_dir UT as an example because it's the first failing test. This problem is not limited to this UT.

cat unit_tests/codec_dir.dir/tok.out -e
```
$
Wed Jul 15 12:31:04.553$
+ lmake codec_py1 codec_py2$
$
^[[38;2;80;112;80m12:31:05 new                src                  ut.py^[[0m$
^[[38;2;128;255;128m12:31:05 done               CodecPy1      0.126s codec_py1^[[0m$
^[]0;done:1 running:1 - ETE:0.000s^G^[[38;2;128;255;128m12:31:06 done               CodecPy2      1.118s codec_py2^[[0m$
^[]0;done:2 running:0 - ETE:0.000s^G^[[38;2;64;160;255m+---------+$
| SUMMARY |$
+---------+^[[0m$
^[[38;2;128;255;128mdone    time : 1.245s (2 jobs)^[[0m$
^[[38;2;64;160;255melapsed time : 1.129s^[[0m$
```

Because of the audit stats (`^[]0;done:1 running:1 - ETE:0.000s^G`), the regex in ut.py fails to recognize the second done key here: (`unit_tests/codec_dir.dir/tok.err`)
```
read config because it was never read
Traceback (most recent call last):
  File "/home/tsu/analysis/open-lmake/unit_tests/codec_dir.dir/Lmakefile.py", line 86, in <module>
    ut.lmake( 'codec_py1'   , 'codec_py2'   , new=1 , done=2 )
  File "/home/tsu/analysis/open-lmake/_lib/ut.py", line 94, in lmake
    if wait : return proc()
                     ^^^^^^
  File "/home/tsu/analysis/open-lmake/_lib/ut.py", line 88, in __call__
    if cnt[k]!=self.kwds.get(k,0) : raise RuntimeError(f'bad count for {k} : {cnt[k]} != {self.kwds.get(k,0)}')
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: bad count for done : 1 != 2
```

This occurs when LMAKE_ARGS=-Vd, because audit stats are displayed when LMAKE_VIDEO != Maybe.
Fixing the regex in `_lib/ut.py:74` seems coherent with the idea that color-related characters are already cleaned out, to handle the possibility of an externally set LMAKE_VIDEO.

Per `src/lmake_server/global.x.hh:394`, when the terminal title is set, it ends with an alert / terminal bell special character (`\a`), so that's what I'm using to detect the audit stats in the regex.