### PR TITLE
add test reproducing server crash when resources eval reads new deps

### DIFF
--- a/unit_tests/dyn_resources_deps.py
+++ b/unit_tests/dyn_resources_deps.py
@@ -1,0 +1,41 @@
+# This file is part of the open-lmake distribution (git@github.com:cesar-douady/open-lmake.git)
+# Copyright (c) 2023-2026 Doliam
+# This program is free software: you can redistribute/modify under the terms of the GPL-v3 (https://www.gnu.org/licenses/gpl-3.0.html).
+# This program is distributed WITHOUT ANY WARRANTY, without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+import lmake
+
+if __name__!='__main__' :
+
+	from lmake.rules import Rule
+
+	lmake.manifest = (
+		'Lmakefile.py'
+	,	'src'
+	,	'extra'
+	,	'trigger'
+	)
+
+	def cpu() :
+		if open('trigger').read().strip()=='go' : # false on 1st run, true on 2nd one
+			open('src'  ).read()                  # src is also a dep of Dut, stored as a chunk header
+			open('extra').read()                  # extra has never been seen by Dut : force deps rebuild
+		return 1
+
+	class Dut(Rule) :
+		target    = 'out'
+		resources = { 'cpu' : cpu }
+		cmd       = '[ -f hole ] ; echo "$(<src)"' # access non-existing hole, then src, with no external process in between
+
+else :
+
+	import ut
+
+	print(1   ,file=open('src'    ,'w'))
+	print('no',file=open('trigger','w'))
+	print(''  ,file=open('extra'  ,'w'))
+	ut.lmake( 'out' , done=1 ,             new=2 ) # normal run, records deps hole (non-existing) then src
+
+	print(2   ,file=open('src'    ,'w'))           # force Dut to rerun
+	print('go',file=open('trigger','w'))           # from now on, cpu() reads src & extra at submit time
+	ut.lmake( 'out' , done=1 , changed=2 , new=1 ) # check resources deps are merged into job deps w/o crash


### PR DESCRIPTION
Reproduce assertion failure @src/rpc_job.hh in DepDigestBase::operator|= : !ddb.sz
Scenario :
 - job deps contain a compressed chunk : a non-existing dep (hole) immediately followed by an existing one (src), making src a chunk header with sz != 0
 - on 2nd run, resources eval reads a brand new file (extra), forcing deps to be rebuilt, and src, which collides with the stored chunk header in the merge loop

AI analysis on bug resolution:
Root cause : `Dep`s obtained by iterating stored `Deps` are not always "clean" standalone deps. `DepsIter::operator*` (src/lmake_server/node.x.hh:252) returns `hdr->hdr` as is when the iterator is on a chunk header, so the resulting `Dep` still carries the storage-only fields `sz` (and `chunk_accesses_`). For a standalone dep these fields are meaningless — cf the comment in `_append_dep` (src/lmake_server/node.cc) : "dep may have a non-null sz (which is not significant as far as the dep alone is concerned)", where they are cleared before re-insertion.

The crash site is the merge loop in `JobData::_submit_plain` (src/lmake_server/job_data.cc:1218-1223) : old Full deps are iterated from `deps` and passed to `DepDigestBase::operator|=`, which asserts `!ddb.sz` (src/rpc_job.hh:614). It is the only call site reachable with such deps today, but `operator==` has the same `!sz` precondition (src/rpc_job.hh:553), so any future caller mixing iterated deps with these operators is exposed the same way.

Points to keep in mind :
- `ddb.sz` plays no role in the merge semantics of `operator|=` : it is pure chunk-navigation info (`GenericDep::next()` uses it to locate the next chunk).
- the fix must not write through the iterator's reference : for a chunk header it points into the mapped store, and `sz` is what makes chunk navigation work, so clearing it in place would corrupt the stored deps.
- in the same loop, the `push_back(d)` branch also propagates `sz!=0` into `new_deps` ; harmless today only because `Deps::assign` clears `sz` when re-chunking.

Possible approaches (not mutually exclusive, no choice made here) :
- copy the dep and clear `sz`/`chunk_accesses_` at the merge site (possibly via a small `DepDigestBase` helper rather than poking fields from job_data.cc),
- make `operator|=` (and/or `operator==`) ignore `ddb.sz` instead of asserting,
- make `DepsIter::operator*` return the header through `tmpl` with `sz` cleared (at the cost of a copy per dereference on a hot path).

For what it's worth, clearing `sz` on a local copy at the merge site was tested against that new unit test.

Present since 26.03.0 (56fe1bb2 "fixed bad dep reporting when computing dynamic attributes") ; affects 26.03.x, 26.06.x and main. Before that commit the code path did not exist (resources deps were not merged into job deps).